### PR TITLE
Enhancements to frames and dialogs

### DIFF
--- a/src/main/java/fr/minecraftforgefrance/installer/CreditFrame.java
+++ b/src/main/java/fr/minecraftforgefrance/installer/CreditFrame.java
@@ -3,13 +3,14 @@ package fr.minecraftforgefrance.installer;
 import static fr.minecraftforgefrance.common.Localization.LANG;
 
 import java.awt.Desktop;
-import java.awt.Dimension;
+import java.awt.Frame;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.net.URI;
 
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
+import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -17,15 +18,18 @@ import javax.swing.JPanel;
 
 import fr.minecraftforgefrance.common.RemoteInfoReader;
 
-public class CreditFrame extends JFrame
+public class CreditFrame extends JDialog
 {
     private static final long serialVersionUID = 1L;
 
-    public CreditFrame(Dimension dim)
+    public CreditFrame(Frame parent)
     {
+    	super(parent);
         this.setTitle(LANG.getTranslation("title.credits"));
         this.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         this.setResizable(false);
+        this.setModalityType(ModalityType.APPLICATION_MODAL);
+
         JPanel panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
 
@@ -69,8 +73,6 @@ public class CreditFrame extends JFrame
         panel.add(sponsorPanel);
         this.add(panel);
         this.pack();
-        int x = (dim.width / 2) - (this.getSize().width / 2);
-        int y = (dim.height / 2) - (this.getSize().height / 2);
-        this.setLocation(x, y);
+        this.setLocationRelativeTo(parent);
     }
 }

--- a/src/main/java/fr/minecraftforgefrance/installer/InstallerFrame.java
+++ b/src/main/java/fr/minecraftforgefrance/installer/InstallerFrame.java
@@ -43,6 +43,7 @@ public class InstallerFrame extends JFrame implements IInstallRunner
         this.setTitle(String.format(LANG.getTranslation("title.installer"), RemoteInfoReader.instance().getModPackDisplayName()));
         this.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         this.setResizable(false);
+
         if(RemoteInfoReader.instance().hasPreset())
         {
             try
@@ -132,7 +133,7 @@ public class InstallerFrame extends JFrame implements IInstallRunner
             @Override
             public void actionPerformed(ActionEvent e)
             {
-                CreditFrame credit = new CreditFrame(dim);
+                CreditFrame credit = new CreditFrame(InstallerFrame.this);
                 credit.setVisible(true);
             }
         });
@@ -144,7 +145,7 @@ public class InstallerFrame extends JFrame implements IInstallRunner
             @Override
             public void actionPerformed(ActionEvent e)
             {
-                OptionFrame credit = new OptionFrame(dim);
+                OptionFrame credit = new OptionFrame(InstallerFrame.this);
                 credit.setVisible(true);
             }
         });
@@ -187,10 +188,7 @@ public class InstallerFrame extends JFrame implements IInstallRunner
             }
         });
         this.pack();
-
-        int x = (dim.width / 2) - (this.getSize().width / 2);
-        int y = (dim.height / 2) - (this.getSize().height / 2);
-        this.setLocation(x, y);
+        this.setLocationRelativeTo(null);
 
         addKeyListener(new KeyListener()
         {

--- a/src/main/java/fr/minecraftforgefrance/installer/OptionFrame.java
+++ b/src/main/java/fr/minecraftforgefrance/installer/OptionFrame.java
@@ -3,7 +3,7 @@ package fr.minecraftforgefrance.installer;
 import static fr.minecraftforgefrance.common.Localization.LANG;
 
 import java.awt.Color;
-import java.awt.Dimension;
+import java.awt.Frame;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
@@ -33,11 +33,13 @@ public class OptionFrame extends JDialog
     public JLabel infoLabel;
     private JTextField selectedDirText;
 
-    public OptionFrame(Dimension dim)
+    public OptionFrame(Frame parent)
     {
         this.setTitle(LANG.getTranslation("title.options"));
         this.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         this.setResizable(false);
+        this.setModalityType(ModalityType.APPLICATION_MODAL);
+
         JPanel mainPanel = new JPanel();
         mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.PAGE_AXIS));
 
@@ -175,9 +177,7 @@ public class OptionFrame extends JDialog
 
         this.add(mainPanel);
         this.pack();
-        int x = (dim.width / 2) - (this.getSize().width / 2);
-        int y = (dim.height / 2) - (this.getSize().height / 2);
-        this.setLocation(x, y);
+        this.setLocationRelativeTo(parent);
         this.updateMinecraftDir(EnumOS.getMinecraftDefaultDir());
     }
 

--- a/src/main/java/fr/minecraftforgefrance/installer/SuccessFrame.java
+++ b/src/main/java/fr/minecraftforgefrance/installer/SuccessFrame.java
@@ -3,14 +3,13 @@ package fr.minecraftforgefrance.installer;
 import static fr.minecraftforgefrance.common.Localization.LANG;
 
 import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.IOException;
 
 import javax.swing.JButton;
+import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -18,7 +17,7 @@ import javax.swing.JPanel;
 
 import fr.minecraftforgefrance.common.EnumOS;
 
-public class SuccessFrame extends JFrame
+public class SuccessFrame extends JDialog
 {
     private static final long serialVersionUID = 1L;
     private boolean launcherExist = false;
@@ -26,12 +25,13 @@ public class SuccessFrame extends JFrame
 
     public SuccessFrame()
     {
-        Dimension dim = Toolkit.getDefaultToolkit().getScreenSize();
         this.setTitle(LANG.getTranslation("misc.success"));
         this.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         this.setResizable(false);
         this.setSize(300, 100);
         this.setLayout(new BorderLayout());
+        this.setModalityType(ModalityType.APPLICATION_MODAL);
+
         JPanel panel = new JPanel();
         JLabel label = new JLabel(LANG.getTranslation("installation.success"));
         label.setAlignmentX(CENTER_ALIGNMENT);
@@ -97,9 +97,7 @@ public class SuccessFrame extends JFrame
             buttonPanel.add(runGame);
         }
         this.getContentPane().add(buttonPanel, BorderLayout.SOUTH);
-
-        int x = (dim.width / 2) - (this.getSize().width / 2);
-        int y = (dim.height / 2) - (this.getSize().height / 2);
-        this.setLocation(x, y);
+        
+        this.setLocationRelativeTo(null);
     }
 }


### PR DESCRIPTION
* Replaced some JFrames by JDialogs (which are more appropriate in this case)

* Added modality for JDialogs, makes underlying frames unusable while the dialogs are shown.

* Replaced ALL setLocation() by setLocationRelativeTo(), which removes the necessity of calculations : this method already handles them. Plus the JDialogs now pop where they are supposed to and not just in the middle of the screen. (their location are relative to their parent for CreditFrame and OptionFrame)

(This PR is an improved and fixed version of #21 , which originally only included the setLocation to setLocationRelativeTo modification for SuccessFrame)